### PR TITLE
Fix README formatting and remove patch remnants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,32 @@
 # reMarkable
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/README.md b/README.md
-index 043622834b587363374e5dda3eeb00f139ff4e5f..4dc118f8a5c43c279b3b21db6f754cc70851d80b 100644
---- a/README.md
-+++ b/README.md
-@@ -1,2 +1,32 @@
- # reMarkable
--This repo is for my reMarkable Tablet
-+
-+This repo contains utilities for my reMarkable Tablet.
-+
-+## NYT Top Stories Script
-+
-+`nyt_to_remarkable.py` downloads the latest New York Times top stories, converts them to PDFs, and uploads them to the reMarkable using [`rmapi`](https://github.com/juruen/rmapi).
-+
-+### Requirements
-+- Python 3
-+- `requests`, `pdfkit`, `readability-lxml`, and `beautifulsoup4` Python packages
-+- [`wkhtmltopdf`](https://wkhtmltopdf.org/) for PDF generation
-+- `rmapi` configured with your reMarkable account
-+
-+### Environment Variables
-+- `NYT_API_KEY` – your New York Times API key (required)
-+- `NYT_SECTION` – section to fetch (default: `home`)
-+- `MAX_ARTICLES` – number of articles to download (default: `5`)
-+- `OUTPUT_DIR` – directory for generated PDFs (default: `nyt_pdfs`)
-+
-+### Usage
-+```bash
-+./nyt_to_remarkable.py
-+```
-+This will create PDFs in the output directory and upload them to your tablet.
-+
-+### Scheduling Daily Runs
-+Add a cron entry to run the script every morning at 6 AM:
-+```cron
-+0 6 * * * /usr/bin/python3 /path/to/nyt_to_remarkable.py >> /path/to/nyt_sync.log 2>&1
-+```
-+Make sure the environment variables above are set for the cron job.
- 
-EOF
-)
+
+This repo contains utilities for my reMarkable Tablet.
+
+## NYT Top Stories Script
+
+`nyt_to_remarkable.py` downloads the latest New York Times top stories, converts them to PDFs, and uploads them to the reMarkable using [`rmapi`](https://github.com/juruen/rmapi).
+
+### Requirements
+- Python 3
+- `requests`, `pdfkit`, `readability-lxml`, and `beautifulsoup4` Python packages
+- [`wkhtmltopdf`](https://wkhtmltopdf.org/) for PDF generation
+- `rmapi` configured with your reMarkable account
+
+### Environment Variables
+- `NYT_API_KEY` – your New York Times API key (required)
+- `NYT_SECTION` – section to fetch (default: `home`)
+- `MAX_ARTICLES` – number of articles to download (default: `5`)
+- `OUTPUT_DIR` – directory for generated PDFs (default: `nyt_pdfs`)
+
+### Usage
+```bash
+./nyt_to_remarkable.py
+```
+This will create PDFs in the output directory and upload them to your tablet.
+
+### Scheduling Daily Runs
+Add a cron entry to run the script every morning at 6 AM:
+```cron
+0 6 * * * /usr/bin/python3 /path/to/nyt_to_remarkable.py >> /path/to/nyt_sync.log 2>&1
+```
+Make sure the environment variables above are set for the cron job.

--- a/nyt_to_remarkable.py
+++ b/nyt_to_remarkable.py
@@ -1,70 +1,61 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a//dev/null b/nyt_to_remarkable.py
-index 0000000000000000000000000000000000000000..5dc239696e3c1c18d9d8436793192802fd80cc6c 100755
---- a//dev/null
-+++ b/nyt_to_remarkable.py
-@@ -0,0 +1,61 @@
-+#!/usr/bin/env python3
-+"""Download NYT top stories and upload them to reMarkable."""
-+import os
-+import requests
-+import subprocess
-+import pdfkit
-+from readability import Document
-+from bs4 import BeautifulSoup
-+from datetime import datetime
-+
-+NYT_API_KEY = os.environ.get("NYT_API_KEY")
-+NYT_SECTION = os.environ.get("NYT_SECTION", "home")
-+MAX_ARTICLES = int(os.environ.get("MAX_ARTICLES", 5))
-+OUTPUT_DIR = os.environ.get("OUTPUT_DIR", "nyt_pdfs")
-+
-+
-+def slugify(text: str) -> str:
-+    """Simplistic slugify function."""
-+    return "".join(c if c.isalnum() else "-" for c in text).strip("-").lower()
-+
-+
-+def fetch_top_articles():
-+    url = f"https://api.nytimes.com/svc/topstories/v2/{NYT_SECTION}.json"
-+    resp = requests.get(url, params={"api-key": NYT_API_KEY})
-+    resp.raise_for_status()
-+    data = resp.json()
-+    return data.get("results", [])[:MAX_ARTICLES]
-+
-+
-+def fetch_article_html(url: str) -> str:
-+    resp = requests.get(url)
-+    resp.raise_for_status()
-+    return resp.text
-+
-+
-+def html_to_pdf(html: str, output_path: str):
-+    pdfkit.from_string(html, output_path)
-+
-+
-+def upload_to_remarkable(path: str):
-+    subprocess.run(["rmapi", "put", path], check=True)
-+
-+
-+def main():
-+    if not NYT_API_KEY:
-+        raise SystemExit("NYT_API_KEY environment variable not set")
-+    os.makedirs(OUTPUT_DIR, exist_ok=True)
-+
-+    articles = fetch_top_articles()
-+    for article in articles:
-+        html = fetch_article_html(article["url"])
-+        doc = Document(html)
-+        content = f"<h1>{article['title']}</h1>" + doc.summary()
-+        pdf_name = f"{datetime.now().date()}_{slugify(article['title'])}.pdf"
-+        pdf_path = os.path.join(OUTPUT_DIR, pdf_name)
-+        html_to_pdf(content, pdf_path)
-+        upload_to_remarkable(pdf_path)
-+
-+
-+if __name__ == "__main__":
-+    main()
- 
-EOF
-)
+#!/usr/bin/env python3
+"""Download NYT top stories and upload them to reMarkable."""
+import os
+import requests
+import subprocess
+import pdfkit
+from readability import Document
+from bs4 import BeautifulSoup
+from datetime import datetime
+
+NYT_API_KEY = os.environ.get("NYT_API_KEY")
+NYT_SECTION = os.environ.get("NYT_SECTION", "home")
+MAX_ARTICLES = int(os.environ.get("MAX_ARTICLES", 5))
+OUTPUT_DIR = os.environ.get("OUTPUT_DIR", "nyt_pdfs")
+
+
+def slugify(text: str) -> str:
+    """Simplistic slugify function."""
+    return "".join(c if c.isalnum() else "-" for c in text).strip("-").lower()
+
+
+def fetch_top_articles():
+    url = f"https://api.nytimes.com/svc/topstories/v2/{NYT_SECTION}.json"
+    resp = requests.get(url, params={"api-key": NYT_API_KEY})
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("results", [])[:MAX_ARTICLES]
+
+
+def fetch_article_html(url: str) -> str:
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.text
+
+
+def html_to_pdf(html: str, output_path: str):
+    pdfkit.from_string(html, output_path)
+
+
+def upload_to_remarkable(path: str):
+    subprocess.run(["rmapi", "put", path], check=True)
+
+
+def main():
+    if not NYT_API_KEY:
+        raise SystemExit("NYT_API_KEY environment variable not set")
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    articles = fetch_top_articles()
+    for article in articles:
+        html = fetch_article_html(article["url"])
+        doc = Document(html)
+        content = f"<h1>{article['title']}</h1>" + doc.summary()
+        pdf_name = f"{datetime.now().date()}_{slugify(article['title'])}.pdf"
+        pdf_path = os.path.join(OUTPUT_DIR, pdf_name)
+        html_to_pdf(content, pdf_path)
+        upload_to_remarkable(pdf_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- clean up README so it only includes the final markdown
- strip patch wrapper lines from the Python script

## Testing
- `python3 -m py_compile nyt_to_remarkable.py`

------
https://chatgpt.com/codex/tasks/task_e_685dd0013f248330b8a091ca3807dec8